### PR TITLE
[37] 문서 삭제 기능

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -32,3 +32,8 @@ export const saveDocApi = async ({ id, body }) => {
   const res = await axios.put(`/api/docs/${id}`, { body });
   return res;
 };
+
+export const deleteDocApi = async (id) => {
+  const res = await axios.delete(`/api/docs/${id}`);
+  return res;
+};

--- a/src/components/MyDocs/DocBox.js
+++ b/src/components/MyDocs/DocBox.js
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
 import { convertDate, convertUpdatedDate } from "../../utils/utils";
+import { deleteDocApi } from "../../api";
+import { useMutation, useQueryClient } from "react-query";
 
 const DocContainer = styled.div`
   margin: 5px;
@@ -38,6 +40,7 @@ const DocInfo = styled.div`
       width: 30px;
       height: 30px;
       margin: 0 5px;
+      cursor: pointer;
     }
   }
 
@@ -65,9 +68,20 @@ const DocPreview = styled.div`
 
 export default function DocBox({ id, title, createdAt, updatedAt, summary }) {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const deleteDocMutation = useMutation(deleteDocApi, {
+    onSuccess: () => {
+      queryClient.fetchQuery("docsList");
+    },
+  });
 
   const handleArrowButtonClick = () => {
     setIsPreviewOpen(!isPreviewOpen);
+  };
+
+  const handleDeleteClick = () => {
+    deleteDocMutation.mutate(id);
   };
 
   return (
@@ -96,7 +110,11 @@ export default function DocBox({ id, title, createdAt, updatedAt, summary }) {
           <Link to={`/docs/detail/${id}`}>
             <img src="/icons/edit.svg" alt="edit" />
           </Link>
-          <img src="/icons/delete.svg" alt="delete" />
+          <img
+            onClick={handleDeleteClick}
+            src="/icons/delete.svg"
+            alt="delete"
+          />
         </div>
       </DocInfo>
       {isPreviewOpen && (


### PR DESCRIPTION
# [37] 문서 삭제 기능

## 노션 칸반 링크

- [[37] 문서 삭제 기능](https://www.notion.so/lazymole/e565da58784e40cdb680fb10378cac2f)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: 문서 삭제 API 추가
- Feat: 문서 삭제 기능 추가
